### PR TITLE
refactor doAPICall, add some helper methods, add nicer error message

### DIFF
--- a/R/download.R
+++ b/R/download.R
@@ -19,6 +19,7 @@
 #'   HTTP request method. Currently one of GET, POST or DELETE.
 #' @param ...
 #'   Another possibility to pass key-value pairs for the HTTP request query.
+#'   Arguments passed via ... have a higher priority.
 #' @return [\code{character(1)}]\cr Unparsed content of the returned XML file.
 #' @export
 #' @keywords internal
@@ -30,47 +31,76 @@ doAPICall = function(api.call, id = NULL,
   # get config infos
   conf = getOMLConfig()
 
-  # occasionally we need to pass a single API arg, such as the data id, additionally
-  id = if (!is.null(id)) paste0("/", id) else ""
-
-  # create HTTP GET args list
-  if (method == "GET") {
-    url.args = insert(url.args, list(...))
-  }
-  #url.args$api_key = conf$apikey
-  url.args = collapseNamedList(url.args)
-
-  # create url
-  if (url.args == "")
-    url = sprintf("%s/%s%s", conf$server, api.call, id)
-  else
-    url = sprintf("%s/%s%s?%s", conf$server, api.call, id, url.args)
+  # build request URL and query
+  url = buildRequestURL(conf$server, api.call, id, url.args, ...)
+  query = list(api_key = conf$apikey)
 
   if (nchar(url) > 4068)
-    stopf("'%s' has %s characters, the maximum allowed url length is 4068.", url, nchar(url))
+    stopf("'%s' has %i characters, the maximum allowed url length is 4068.", url, nchar(url))
 
+  # some nice output to the user
   if (method == "GET") {
     showInfo(verbosity, "%s '%s' to '%s'.", "Downloading from", url,
       ifelse(is.null(file), "<mem>", file))
-    content = GET(url = url, query = list(api_key = conf$apikey))
-    content = rawToChar(content$content)
   } else {
     from.url = ifelse(method == "POST", "Uploading to", "Deleting from")
     showInfo(verbosity, "%s '%s'.", from.url, url)
-    if (method == "POST") {
-      content = POST(url = url, body = post.args, query = list(api_key = conf$apikey))
-    } else if (method == "DELETE")
-      content = DELETE(url = url, query = list(api_key = conf$apikey))
   }
 
+  # finally to the call
+  content = doHTTRCall(method,
+    url = url,
+    query = list(api_key = conf$apikey),
+    body = if (length(post.args) > 0) post.args else NULL)
+
+  # write response to file
   if (!is.null(file)) {
     con = file(file, open = "w")
     on.exit(close(con))
     writeLines(content, con = con)
   }
+
   return(content)
 }
 
+# Helper function to generate HTTP request URL to access functionality of the
+# OpenML backend.
+buildRequestURL = function(server, api.call, id, url.args, ...) {
+  # occasionally we need to pass a single API arg, such as the data id, additionally
+  id = if (!is.null(id)) paste0("/", id) else ""
+
+  #url.args$api_key = conf$apikey
+  url.args = collapseNamedList(url.args)
+
+  # create url of form
+  # http://www.openml.org/apicall/id/[?key1=value1&key2=value2&...]
+  if (url.args == "")
+    url = sprintf("%s/%s%s", server, api.call, id)
+  else
+    url = sprintf("%s/%s%s?%s", server, api.call, id, url.args)
+  return(url)
+}
+
+# Helper function to transform named list to HTTP query string.
+# E.g. list(x = 123, y = openml) to x=123&y=openml.
 collapseNamedList = function(args, sep = "=", collapse = "&") {
   collapse(paste(names(args), args, sep = sep), collapse)
+}
+
+# Helper function to do HTTP request.
+# This function checks for errors.
+doHTTRCall = function(method = "GET", url, query, body = NULL) {
+  # build list of args for the httr::method call
+  http.args = list(url = url, body = body, query = query)
+  # filter empty body
+  http.args = filterNull(http.args)
+  # do the request and catch potential "unreadable" curl errors
+  server.response = try(do.call(method, http.args), silent = TRUE)
+  if (is.error(server.response)) {
+    stopf("API call failed. Maybe you are not connected to the internet.")
+  }
+  # if we requested a document we need to extract the actual content
+  if (method == "GET")
+    server.response = rawToChar(server.response$content)
+  return(server.response)
 }

--- a/man/doAPICall.Rd
+++ b/man/doAPICall.Rd
@@ -34,7 +34,8 @@ Default is set via \code{\link{setOMLConfig}}.}
 \item{method}{[\code{character(1)}]\cr
 HTTP request method. Currently one of GET, POST or DELETE.}
 
-\item{...}{Another possibility to pass key-value pairs for the HTTP request query.}
+\item{...}{Another possibility to pass key-value pairs for the HTTP request query.
+Arguments passed via ... have a higher priority.}
 }
 \value{
 [\code{character(1)}]\cr Unparsed content of the returned XML file.


### PR DESCRIPTION
Refactored `doAPICall`.
- Added helper methods `buildRequestURL` and `doHTTRCall`
- Added a lot of helpful comments
- Extended docs of dotargs
- Catched potential curl errors (see issue #227)

Points to discuss:
- I wrapped the httr::method calls with `try(..., silent = TRUE)`. I know @berndbischl does not like that. Maybe @berndbischl could propose an alternative/better approach.
- Should we print the original error message as well? I guess so.