### PR TITLE
consistent error handling in doAPICall

### DIFF
--- a/R/deleteOMLObject.R
+++ b/R/deleteOMLObject.R
@@ -1,10 +1,10 @@
 #' @title Delete an OpenML object.
 #'
 #' @description
-#' This will delete one of your uploaded datasets, tasks, flows or runs. 
+#' This will delete one of your uploaded datasets, tasks, flows or runs.
 #' Note that you can only delete the objects you uploaded.
-#' 
-#' @template arg_id 
+#'
+#' @template arg_id
 #' @template arg_object
 #' @template arg_verbosity
 #' @family data set-related functions
@@ -16,13 +16,11 @@ deleteOMLObject = function(id, object = c("data", "task", "flow", "run"), verbos
   id = asCount(id)
   assertChoice(object, choices = c("data", "task", "flow", "run"))
 
-  response = try(doAPICall(api.call = object, method = "DELETE", id = id))
+  response = doAPICall(api.call = object, method = "DELETE", id = id)
 
-  if (is.error(response))
-    stopf("Unknown %1$s. Please check the %1$s id", object)
   if (!is.null(content(response)))
     parseXMLResponse(response, paste("Deleting", object), paste0(object, "_delete"), as.text = TRUE)
   showInfo(verbosity, "The %s with ID %s was succesfully deleted.", object, id)
-  
+
   return(invisible(response))
 }

--- a/R/download.R
+++ b/R/download.R
@@ -151,7 +151,10 @@ parseHTMLError = function(response) {
 # see parseHTMLError for signature
 parseXMLError = function(response) {
   content = rawToChar(response$content)
-  xml.doc = xmlParse(content, asText = TRUE)
+  xml.doc = try(xmlParse(content, asText = TRUE), silent = TRUE)
+  if (is.error(xml.doc)) {
+    return(list(code = "<NA>", message = "<NA>", extra = "Unable to parse XML error response."))
+  }
   list(
     code = xmlRValI(xml.doc, "/oml:error/oml:code"),
     message = xmlOValS(xml.doc, "/oml:error/oml:message")

--- a/R/xml_helpers.R
+++ b/R/xml_helpers.R
@@ -126,27 +126,14 @@ xmlValsMultNsN = function(doc, path) {
   xmlValsMultNs(doc, path, as.numeric, numeric(1L))
 }
 
-parseXMLResponse = function(file, msg = NA_character_, 
+parseXMLResponse = function(file, msg = NA_character_,
   type = NA_character_, as.text = FALSE, return.doc = TRUE) {
-  
+
   doc = try(xmlParse(file, asText = as.text))
   if (is.error(doc))
     stopf("Error in parsing XML for type %s in file: %s", type, file)
 
   r = xmlRoot(doc)
-  rootname = xmlName(r)
-  if (rootname == "error") {
-    extra = xmlOValS(doc, "/oml:error/oml:additional_information")
-    code = xmlRValI(doc, "/oml:error/oml:code")
-    stopf("Error (code = %i) in server / XML response for: %s\n\t\t%s.\n\t\t%s",
-      code, msg, xmlRValS(doc, "/oml:error/oml:message"), ifelse(is.null(extra), "", extra)
-    )
-  }
-
-  #  FIXME: do we need this here?
-  # fp = ifelse(as.text, "<TEXT>", file)
-  #  if (rootname %nin% type)
-  #    stopf("Expected to find XML type %s, not %s, in file %s", collapse(type, " or "), rootname, fp)
 
   if (return.doc)
     return(doc)

--- a/man/deleteOMLObject.Rd
+++ b/man/deleteOMLObject.Rd
@@ -23,7 +23,7 @@ Print verbose output on console? Possible values are:\cr
 Default is set via \code{\link{setOMLConfig}}.}
 }
 \description{
-This will delete one of your uploaded datasets, tasks, flows or runs. 
+This will delete one of your uploaded datasets, tasks, flows or runs.
 Note that you can only delete the objects you uploaded.
 }
 \seealso{

--- a/tests/testthat/test_server_deleteOMLObject.R
+++ b/tests/testthat/test_server_deleteOMLObject.R
@@ -2,8 +2,8 @@ context("deleteOMLObject")
 
 test_that("deleteOMLObject", {
   expect_error(deleteOMLObject(id = 1, object = "run"), "Run is not owned by you")
-  expect_error(deleteOMLObject(id = 123456789, object = "run"), "Run does not exists")
-  
+  expect_error(deleteOMLObject(id = 123456789, object = "run"), "Unknown run")
+
   # local sanity check (account needs read-write permissions)
   with_write_access({
     run = getOMLRun(1)
@@ -11,6 +11,6 @@ test_that("deleteOMLObject", {
     del = deleteOMLObject(id = run.id, object = "run")
     expect_is(del, "response")
     expect_equal(httr::status_code(del), 200)
-    expect_error(deleteOMLObject(id = run.id, object = "run"), "Run does not exists")
+    expect_error(deleteOMLObject(id = run.id, object = "run"), "Unknown run")
   })
 })

--- a/tests/testthat/test_server_deleteOMLObject.R
+++ b/tests/testthat/test_server_deleteOMLObject.R
@@ -2,7 +2,7 @@ context("deleteOMLObject")
 
 test_that("deleteOMLObject", {
   expect_error(deleteOMLObject(id = 1, object = "run"), "Run is not owned by you")
-  expect_error(deleteOMLObject(id = 123456789, object = "run"), "Unknown run")
+  expect_error(deleteOMLObject(id = 123456789, object = "run"), "Run does not exists")
 
   # local sanity check (account needs read-write permissions)
   with_write_access({
@@ -11,6 +11,6 @@ test_that("deleteOMLObject", {
     del = deleteOMLObject(id = run.id, object = "run")
     expect_is(del, "response")
     expect_equal(httr::status_code(del), 200)
-    expect_error(deleteOMLObject(id = run.id, object = "run"), "Unknown run")
+    expect_error(deleteOMLObject(id = run.id, object = "run"), "Run does not exists")
   })
 })


### PR DESCRIPTION
Solves #233 (and #226)
Not finished yet. Parsing XML error responses is missing at the moment.