### PR TITLE
Add mean class complexity logloss mapping

### DIFF
--- a/R/convertOMLMeasuresToMlr.R
+++ b/R/convertOMLMeasuresToMlr.R
@@ -24,7 +24,8 @@ lookupMeasures = function() {
     "c_index" = mlr::cindex,
     "usercpu_time_millis" = mlr::timeboth,
     "usercpu_time_millis_testing" = mlr::timepredict,
-    "usercpu_time_millis_training" = mlr::timetrain
+    "usercpu_time_millis_training" = mlr::timetrain,
+    "mean_class_complexity" = mlr::logloss
   )
   res = lapply(res, mlr::setAggregation, aggr = mlr::test.join)
   res$usercpu_time_millis = mlr::setAggregation(res$usercpu_time_millis, aggr = mlr::test.sum)


### PR DESCRIPTION
We should mybe check if there are more measures that we do not map yet. It's quite annoying since you cannot convert the task even if you ignore the measure.

I think the mapping should be correct (see here https://weka.8497.n7.nabble.com/Evaluating-a-classifier-using-a-log-loss-function-td30182.html)